### PR TITLE
Ensure only one open connection to API node

### DIFF
--- a/rest/src/index.js
+++ b/rest/src/index.js
@@ -154,8 +154,10 @@ const registerRoutes = (server, db, services) => {
 			const connectionService = createConnectionService(config, createConnection, catapult.auth.createAuthPromise, winston.verbose);
 			registerRoutes(server, db, { codec: serverAndCodec.codec, config, connectionService });
 
-			winston.info(`listening on port ${config.port}`);
-			server.listen(config.port);
+			connectionService.lease().then(() => {
+				winston.info(`listening on port ${config.port}`);
+				server.listen(config.port);
+			})
 		})
 		.catch(err => {
 			winston.error('rest server is exiting due to error', err);


### PR DESCRIPTION
When rest gateway receives a burst of transactions on startup, it will open a new connection for each request as `connectionService` has not saved the connection while waiting for the verification to complete.